### PR TITLE
Added key remapping

### DIFF
--- a/Tool Menu/main.lua
+++ b/Tool Menu/main.lua
@@ -24,6 +24,10 @@ function init()
 
     recent_menu_height = 100
     scroll_pos = 0
+    
+    if HasKey('savegame.mod.menu_key') then
+        menu_key = GetString('savegame.mod.menu_key')
+    end
 end
 
 function get_tool_key(tool_id, k)

--- a/Tool Menu/options.lua
+++ b/Tool Menu/options.lua
@@ -1,0 +1,52 @@
+function draw()
+	UiTranslate(UiCenter(), 250)
+	UiAlign("center middle")
+
+	--Title
+	UiFont("bold.ttf", 48)
+	UiText("Tool menu")
+
+	--Keyboard instructions
+	UiFont("regular.ttf", 26)
+	UiTranslate(0, 70)
+	UiPush()
+		UiText("Keyboard Layout")
+		UiTranslate(0, 20)
+		UiFont("regular.ttf", 20)
+		UiText("Defines which key is used to make the menu appearing.")
+		UiTranslate(0, 20)
+		UiText("QWERTY will set the key to 'q'. AZERTY will set the key to 'a'.")
+	UiPop()
+
+    --Buttons
+	UiTranslate(0, 80)
+	UiFont("regular.ttf", 26)
+	UiButtonImageBox("ui/common/box-outline-6.png", 6, 6)
+	UiPush()
+		UiTranslate(-110, 0)
+		if GetString("savegame.mod.menu_key") == "q" then
+			UiPush()
+				UiColor(0.5, 1, 0.5, 0.2)
+				UiImageBox("ui/common/box-solid-6.png", 200, 40, 6, 6)
+			UiPop()
+		end
+		if UiTextButton("QWERTY Keyboard", 200, 40) then
+			SetString("savegame.mod.menu_key", "q")
+		end
+		UiTranslate(220, 0)
+		if GetString("savegame.mod.menu_key") == "a" then
+			UiPush()
+				UiColor(0.5, 1, 0.5, 0.2)
+				UiImageBox("ui/common/box-solid-6.png", 200, 40, 6, 6)
+			UiPop()
+		end
+		if UiTextButton("AZERTY Keyboard", 200, 40) then
+			SetString("savegame.mod.menu_key", "a")
+		end
+	UiPop()
+	
+	UiTranslate(0, 100)
+	if UiTextButton("Close", 200, 40) then
+		Menu()
+	end
+end


### PR DESCRIPTION
Well sort of, because the Teardown API doesn't provide a simple way of knowing which key is pressed by the user, I had to make a keyboard layout selector available through the mod options. There are two layout as of now, the QWERTY as a default and the AZERTY one, the user can select any one of them and the choice is stored in the save file of the mod using the Teardown registry.