### PR TITLE
Fix favoriting

### DIFF
--- a/Tool Menu/main.lua
+++ b/Tool Menu/main.lua
@@ -109,7 +109,7 @@ function load_favorite_tools()
     for i, tool_id in ipairs(tool_ids) do
         local index = tonumber(get_tool_key(tool_id, 'index'))
         if tonumber(index) ~= nil then
-            all_tools[index].favorite = true
+            all_tools[index+1].favorite = true
         end
     end
 end


### PR DESCRIPTION
The favorites system currently doesn't load the right index in load_favorite_tools(), instead it loads 1 index less than it should, this should fix that and make favorites load properly.