### PR TITLE
Fix for favorites not reading from persistent correctly

### DIFF
--- a/Tool Menu/main.lua
+++ b/Tool Menu/main.lua
@@ -113,11 +113,10 @@ function load_favorite_tools()
     local tool_ids = split(fav_string, ',')
 
     -- update the favorite status of the tools
-    for i, tool_id in ipairs(tool_ids) do
-        local index = tonumber(get_tool_key(tool_id, 'index'))
-        if tonumber(index) ~= nil then
-            all_tools[index].favorite = true
-        end
+    for i, tool in ipairs(all_tools) do
+        if table_contains(tool_ids, tool.id) then
+			all_tools[i].favorite = true
+		end
     end
 end
 


### PR DESCRIPTION
I have created a steam post concerning this problem of favorites not able to be read correctly from persistent:
https://steamcommunity.com/workshop/filedetails/discussion/2418422455/3452591533721928416/

Also please check if this fix works on other environments without the mitigation of the invalid order function for me to use this mod.

Possibly the invalid order function needs to be tackled as well since other people in the comment of the steam workshop also said about this issue.